### PR TITLE
Cleanup Typescript types, definitions, and declarations

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -75,7 +75,7 @@ export default function App() {
   });
 
   async function handleGetProfile(e: React.MouseEvent<HTMLElement>) {
-    setCurrentChannel(e.target.getAttribute("data-channelid"));
+    setCurrentChannel(e.currentTarget.getAttribute("data-channelid"));
     await queryClient.invalidateQueries({ queryKey: ["channel"] });
     await queryClient.refetchQueries({ queryKey: ["channel"] });
   }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,7 +11,7 @@ import Video from "./components/Video";
 dayjs.extend(calendar);
 dayjs.extend(relativeTime);
 
-type ResponseChannel = {
+export type ResponseChannel = {
   english_name: string;
   id: string;
   name: string;
@@ -21,7 +21,7 @@ type ResponseChannel = {
   type: string;
 };
 
-type ResponseChannelInfo = {
+export type ResponseChannelInfo = {
   banner: string;
   english_name: string;
   id: string;
@@ -33,7 +33,7 @@ type ResponseChannelInfo = {
   view_count: number;
 };
 
-type ResponseVideo = {
+export type ResponseVideo = {
   available_at: string;
   channel: ResponseChannel;
   duration: number;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import dayjs from "dayjs";
 import calendar from "dayjs/plugin/calendar";

--- a/src/components/ChannelInfo.tsx
+++ b/src/components/ChannelInfo.tsx
@@ -1,36 +1,13 @@
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, UseQueryResult } from "@tanstack/react-query";
 import dayjs from "dayjs";
+import { ResponseChannelInfo, ResponseVideo } from "../App";
 
-type ChannelParamsType = {
+type ChannelInfoParamsType = {
   channelId: string,
 }
 
-type ResponseChannel = {
-  english_name: string,
-  id: string,
-  name: string,
-  org: string,
-  photo: string,
-  suborg: string,
-  type: string
-}
-
-type ResponseVideo = {
-  available_at: string,
-  channel: ResponseChannel,
-  duration: number,
-  id: string,
-  live_viewers: number,
-  published_at: string,
-  start_scheduled: string,
-  status: string,
-  title: string,
-  topic_id: string,
-  type: string
-}
-
-export default function ChannelInfo({ channelId }: ChannelParamsType) {
-  const channel = useQuery({
+export default function ChannelInfo({ channelId }: ChannelInfoParamsType) {
+  const channel: UseQueryResult<ResponseChannelInfo, Error> = useQuery({
     queryKey: ["channel", "info"],
     queryFn: async () => await fetchChannel(channelId),
     retry: 0,

--- a/src/components/Video.tsx
+++ b/src/components/Video.tsx
@@ -1,6 +1,12 @@
 import dayjs from "dayjs";
+import { ResponseVideo } from "../App";
 
-export default function Video({ video, onClickGetProfile }) {
+type VideoParamsType = {
+  video: ResponseVideo,
+  onClickGetProfile: React.MouseEventHandler,
+}
+
+export default function Video({ video, onClickGetProfile }: VideoParamsType) {
   return (
     <article className="border">
       <p>{video.channel.english_name}</p>


### PR DESCRIPTION
## Changes

### Major Changes
Set types in main `App.tsx` file to be exported, then reused in child component files as needed. Updated some type definitions and declarations for posterity.

### Bug Fixes / Minor Changes
- Removed unused import of React hook
- Fix typo where event `e.target` was used instead of `e.currentTarget` preceding a call of `getAttribute()`

## Issues
N/A

## Why
Some type definitions and declarations were missing, so VSCode's syntax highlighting was yelling at me.

## How
N/A

## Notes
N/A
